### PR TITLE
fix: Use pyyaml SafeLoader to suppress deprecation warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The Docker image used by a particular step of the workflow can be identified by 
 | hifiasm | <ul><li>[hifiasm 0.19.4](https://github.com/chhylp123/hifiasm/releases/tag/0.19.4)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/hifiasm) |
 | htslib | <ul><li>[htslib 1.14](https://github.com/samtools/htslib/releases/tag/1.14)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/htslib) |
 | paftools | <ul><li>[paftools 2.26-r1182-dirty](https://github.com/lh3/minimap2/blob/bc588c0eeb26426d0d90a93fb0877358a389c515/misc/paftools.js)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/align_hifiasm) |
-| pyyaml | <ul><li>python 3.8.10; custom scripts</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/cec77c6042cc3c465d252d40c1ade89e3c58cf16/docker/pyyaml) |
+| pyyaml | <ul><li>python 3.8.10; custom scripts</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/e421243d68aed4c7ed85bf90d6a82d738f292a28/docker/pyyaml) |
 | samtools | <ul><li>[samtools 1.14](https://github.com/samtools/samtools/releases/tag/1.14)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/samtools) |
 | yak | <ul><li>[yak 0.1](https://github.com/lh3/yak/releases/tag/v0.1)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/yak) |
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The Docker image used by a particular step of the workflow can be identified by 
 | hifiasm | <ul><li>[hifiasm 0.19.4](https://github.com/chhylp123/hifiasm/releases/tag/0.19.4)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/hifiasm) |
 | htslib | <ul><li>[htslib 1.14](https://github.com/samtools/htslib/releases/tag/1.14)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/htslib) |
 | paftools | <ul><li>[paftools 2.26-r1182-dirty](https://github.com/lh3/minimap2/blob/bc588c0eeb26426d0d90a93fb0877358a389c515/misc/paftools.js)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/align_hifiasm) |
-| pyyaml | <ul><li>python 3.8.10; custom scripts</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/f72e862bca2f209b9909e6043ef0197975762f27/docker/pyyaml) |
+| pyyaml | <ul><li>python 3.8.10; custom scripts</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/cec77c6042cc3c465d252d40c1ade89e3c58cf16/docker/pyyaml) |
 | samtools | <ul><li>[samtools 1.14](https://github.com/samtools/samtools/releases/tag/1.14)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/samtools) |
 | yak | <ul><li>[yak 0.1](https://github.com/lh3/yak/releases/tag/v0.1)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/3560fcc5a84e044067cea9c9a7669cfc2659178e/docker/yak) |
 

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -79,7 +79,7 @@
       "tasks": {
         "parse_families": {
           "key": "parse_families",
-          "digest": "efkaxftmmzkxxyofohztdft7o6pl6oho",
+          "digest": "rsrm6ovjkccljzmidg7yuioyusx3pt2r",
           "tests": [
             {
               "inputs": {

--- a/workflows/de_novo_assembly_trio/de_novo_assembly_trio.wdl
+++ b/workflows/de_novo_assembly_trio/de_novo_assembly_trio.wdl
@@ -191,7 +191,7 @@ task parse_families {
 	}
 
 	runtime {
-		docker: "~{runtime_attributes.container_registry}/pyyaml@sha256:8749239ba12a78d899f0dba4f55ddc260c42d4bfa60895bd11a628d4cfdef635"
+		docker: "~{runtime_attributes.container_registry}/pyyaml@sha256:f51db733249c29aec06fad2ab02695379aeebabb81fe30f36209d737dd381be1"
 		cpu: 2
 		memory: "4 GB"
 		disk: "20 GB"

--- a/workflows/de_novo_assembly_trio/de_novo_assembly_trio.wdl
+++ b/workflows/de_novo_assembly_trio/de_novo_assembly_trio.wdl
@@ -191,7 +191,7 @@ task parse_families {
 	}
 
 	runtime {
-		docker: "~{runtime_attributes.container_registry}/pyyaml@sha256:af6f0689a7412b1edf76bd4bf6434e7fa6a86192eebf19573e8618880d9c1dbb"
+		docker: "~{runtime_attributes.container_registry}/pyyaml@sha256:8749239ba12a78d899f0dba4f55ddc260c42d4bfa60895bd11a628d4cfdef635"
 		cpu: 2
 		memory: "4 GB"
 		disk: "20 GB"


### PR DESCRIPTION
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

This should also address errors about unsafe loading, like:
```bash
/opt/scripts/calculate_phrank.py:246: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  cohort_list = yaml.load("".join(yamlfile))
```